### PR TITLE
Missing import

### DIFF
--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ably-forks/flynn/pkg/random"
 	"golang.org/x/crypto/nacl/secretbox"
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
 type backendDialer interface {


### PR DESCRIPTION
The commit reverts the removal of the log import. The reason why this
exists, is because the following commit ead47c9bc880b0f6158b0aad95fa554575571330
removed the package from the vendor folder.

None of the flynn tests pass at all now. It seems like the state of the
flynn fork is borked. There are missing packages and broken unit tests
and to fix this would cause a MASSIVE pain.