### PR TITLE
Log copy errors

### DIFF
--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/ably-forks/flynn/pkg/random"
 	"golang.org/x/crypto/nacl/secretbox"
-	"gopkg.in/inconshreveable/log15.v2"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 type backendDialer interface {


### PR DESCRIPTION
The following commit logs all copy errors when copying from writers to
readers. The should help with understanding why some connections can end
up with packets that are not delivered, but they should be.

The error is not surfaced if there was one trying to stream the data.